### PR TITLE
feat/event_feature

### DIFF
--- a/src/main/java/backend/onmoim/domain/event/controller/EventController.java
+++ b/src/main/java/backend/onmoim/domain/event/controller/EventController.java
@@ -1,0 +1,35 @@
+package backend.onmoim.domain.event.controller;
+
+import backend.onmoim.domain.event.dto.res.EventDetailResponse;
+import backend.onmoim.domain.event.dto.req.VoteRequest;
+import backend.onmoim.domain.event.service.EventService;
+import backend.onmoim.global.common.ApiResponse;
+import backend.onmoim.global.common.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/events")
+public class EventController {
+
+    private final EventService eventService;
+
+    @GetMapping("/{eventId}")
+    public ApiResponse<EventDetailResponse> getEventDetail(@PathVariable Long eventId) {
+        EventDetailResponse response = eventService.getEventDetail(eventId);
+
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, response);
+    }
+
+    @PostMapping("/{eventId}/vote")
+    public ApiResponse<String> castVote(@PathVariable Long eventId,
+                                        @RequestBody VoteRequest request) {
+        Long userId = 1L;
+        eventService.castVote(eventId, userId, request);
+
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, "투표가 완료되었습니다.");
+    }
+}

--- a/src/main/java/backend/onmoim/domain/event/dto/req/VoteRequest.java
+++ b/src/main/java/backend/onmoim/domain/event/dto/req/VoteRequest.java
@@ -1,0 +1,11 @@
+package backend.onmoim.domain.event.dto.req; // 👈 패키지 경로에 .req 추가
+
+import backend.onmoim.domain.event.enums.VoteStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VoteRequest {
+    private VoteStatus status;
+}

--- a/src/main/java/backend/onmoim/domain/event/dto/res/EventDetailResponse.java
+++ b/src/main/java/backend/onmoim/domain/event/dto/res/EventDetailResponse.java
@@ -1,0 +1,53 @@
+package backend.onmoim.domain.event.dto.res;
+
+import backend.onmoim.domain.event.entity.Event;
+import backend.onmoim.domain.event.entity.Participation;
+import backend.onmoim.domain.event.enums.VoteStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class EventDetailResponse {
+    private Long eventId;
+    private String title;
+    private LocalDateTime eventDate;
+    private String location;
+    private Integer price;
+    private String playlistUrl;
+    private String content;
+    private List<ParticipantDto> participants;
+    private int totalParticipantCount;
+
+    @Getter
+    @Builder
+    public static class ParticipantDto {
+        private String userName;
+        private VoteStatus status;
+
+        public static ParticipantDto from(Participation participation) {
+            return ParticipantDto.builder()
+                    .userName(participation.getUser().getNickname()) //User에 getNickName이라고 되어있음
+                    .status(participation.getStatus())
+                    .build();
+        }
+    }
+
+
+    public static EventDetailResponse of(Event event, List<ParticipantDto> participants, int totalCount) {
+        return EventDetailResponse.builder()
+                .eventId(event.getId())
+                .title(event.getTitle())
+                .eventDate(event.getEventDate())
+                .location(event.getLocation())
+                .price(event.getPrice())
+                .playlistUrl(event.getPlaylistUrl())
+                .content(event.getContent())
+                .participants(participants)
+                .totalParticipantCount(totalCount)
+                .build();
+    }
+}

--- a/src/main/java/backend/onmoim/domain/event/entity/Event.java
+++ b/src/main/java/backend/onmoim/domain/event/entity/Event.java
@@ -1,0 +1,29 @@
+package backend.onmoim.domain.event.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Event {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private LocalDateTime eventDate;
+
+    private String location;
+
+    private Integer price;
+
+    private String playlistUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/backend/onmoim/domain/event/entity/Participation.java
+++ b/src/main/java/backend/onmoim/domain/event/entity/Participation.java
@@ -1,0 +1,37 @@
+package backend.onmoim.domain.event.entity;
+
+import backend.onmoim.domain.event.enums.VoteStatus;
+import backend.onmoim.domain.user.entity.User; // User 엔티티 import (패키지 경로 확인 필요)
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Participation {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 누가 투표했는지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 어떤 행사에 투표했는지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    // 투표 상태 (참여/고민/불참)
+    @Enumerated(EnumType.STRING)
+    private VoteStatus status;
+
+    // [중요] 상태 변경 메소드 (Service에서 사용)
+    public void updateStatus(VoteStatus newStatus) {
+        this.status = newStatus;
+    }
+}
+//유저와 행사를 연결해준다. 누가 어떤 행사에 투표 했는지 db에 저징

--- a/src/main/java/backend/onmoim/domain/event/enums/VoteStatus.java
+++ b/src/main/java/backend/onmoim/domain/event/enums/VoteStatus.java
@@ -1,0 +1,14 @@
+package backend.onmoim.domain.event.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum VoteStatus {
+    ATTEND("참여!"),
+    PENDING("고민중.."),
+    ABSENT("못가요..");
+
+    private final String description;
+}

--- a/src/main/java/backend/onmoim/domain/event/repository/EventRepository.java
+++ b/src/main/java/backend/onmoim/domain/event/repository/EventRepository.java
@@ -1,0 +1,9 @@
+package backend.onmoim.domain.event.repository;
+
+import backend.onmoim.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+    // 기본적으로 findById, save, delete 등이 자동으로 포함되어 있습니다.
+    // 추가적인 쿼리 메소드가 필요하면 여기에 작성하면 됩니다.
+}

--- a/src/main/java/backend/onmoim/domain/event/repository/ParticipationRepository.java
+++ b/src/main/java/backend/onmoim/domain/event/repository/ParticipationRepository.java
@@ -1,0 +1,17 @@
+package backend.onmoim.domain.event.repository;
+
+import backend.onmoim.domain.event.entity.Event;
+import backend.onmoim.domain.event.entity.Participation;
+import backend.onmoim.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface ParticipationRepository extends JpaRepository<Participation, Long> {
+
+    // 특정 유저가 특정 행사에 남긴 투표 기록 찾기
+    Optional<Participation> findByUserAndEvent(User user, Event event);
+
+    // 특정 행사의 모든 참여자 목록 가져오기
+    java.util.List<Participation> findAllByEvent(Event event);
+}
+//DB에서 "내가 이 행사에 투표한 적이 있나?"를 확인

--- a/src/main/java/backend/onmoim/domain/event/service/EventService.java
+++ b/src/main/java/backend/onmoim/domain/event/service/EventService.java
@@ -1,0 +1,66 @@
+package backend.onmoim.domain.event.service;
+
+import backend.onmoim.domain.event.dto.req.VoteRequest;
+import backend.onmoim.domain.event.dto.res.EventDetailResponse;
+import backend.onmoim.domain.event.entity.Event;
+import backend.onmoim.domain.event.entity.Participation;
+import backend.onmoim.domain.event.repository.EventRepository;
+import backend.onmoim.domain.event.repository.ParticipationRepository;
+import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventService {
+
+    private final EventRepository eventRepository;
+    private final ParticipationRepository participationRepository;
+    private final UserRepository userRepository;
+
+    public EventDetailResponse getEventDetail(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("행사를 찾을 수 없습니다."));
+
+        List<Participation> allParticipations = participationRepository.findAllByEvent(event);
+
+        int totalCount = allParticipations.size();
+
+
+        List<EventDetailResponse.ParticipantDto> participantDtos = allParticipations.stream()
+                .limit(4)
+                .map(EventDetailResponse.ParticipantDto::from)
+                .collect(Collectors.toList());
+
+        return EventDetailResponse.of(event, participantDtos, totalCount);
+    }
+
+
+    @Transactional
+    public void castVote(Long eventId, Long userId, VoteRequest request) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("행사를 찾을 수 없습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        participationRepository.findByUserAndEvent(user, event)
+                .ifPresentOrElse(
+                        existingParticipation -> existingParticipation.updateStatus(request.getStatus()),
+                        () -> {
+                            Participation newParticipation = Participation.builder()
+                                    .user(user)
+                                    .event(event)
+                                    .status(request.getStatus())
+                                    .build();
+                            participationRepository.save(newParticipation);
+                        }
+                );
+    }
+}


### PR DESCRIPTION
- 행사(Event) 및 참여(Participation) 도메인 엔티티/레포지토리 구현
- 행사 상세 조회 API 구현 (GET) 및 4인 노출 제한 로직 적용
- 행사 참여 투표 API 구현 (POST) 및 상태 변경(Upsert) 로직 적용
- DTO 구조 분리 (req/res 패키지 적용) 및 VoteRequest, EventDetailResponse 구현
- GeneralSuccessCode 적용

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
> [!CAUTION]
> 스크린샷 첨부는 **필수**입니다!
> **첨부 후 해당 콜아웃은 지워주세요!!**
<img width="465" height="441" alt="스크린샷 2026-01-29 19 39 28" src="https://github.com/user-attachments/assets/1d220f4e-b485-482d-8cb5-636866833aa0" />
도메인 구성 요소

1. 도메인 설계 (backend.onmoim.domain.event)

- Entity
Event: 행사 기본 정보 (제목, 일시, 장소, 가격, 플레이리스트 등)
Participation: 유저와 행사 간의 N:M 관계를 해소하고 투표 상태를 저장하는 엔티티

Enum: VoteStatus: 투표 상태 관리 (ATTEND(참여), PENDING(고민), ABSENT(불참))

Repository: EventRepository, ParticipationRepository 생성 및 기본 조회 메소드 구현

2. 행사 상세 조회 API 구현
Method: GET
Path: /api/events/{eventId}

기능: 행사 기본 정보와 참여자 목록을 반환합니다.
참여자 노출 제한: 기획 사항에 따라 참여자 리스트는 최대 4명까지만 limit 처리하여 반환합니다.
전체 참여 인원수(totalParticipantCount)를 별도 필드로 계산하여 제공합니다.

DTO: EventDetailResponse (Response DTO)

3. 행사 참여 투표 API 구현
Method: POST
Path: /api/events/{eventId}/vote

기능: 사용자가 행사에 대해 참여/고민/불참 상태를 투표합니다.

Upsert 로직 적용: 기존 투표 이력이 없으면 → 새로운 내역을 INSERT
기존 투표 이력이 있으면 → 기존 상태를 UPDATE (불필요한 데이터 생성 방지)

DTO: VoteRequest (Request DTO)


## 🔗 관련 이슈
-  #9

---

## 💡 추가 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 이벤트 상세 정보 조회 기능 추가 - 행사의 제목, 날짜, 장소, 가격, 플레이리스트, 설명 정보 확인 가능
* 이벤트 투표 기능 추가 - 참석, 보류, 불참석 상태로 투표 가능
* 이벤트별 참여자 목록 및 투표 현황 조회 - 참여자 정보와 총 참가자 수 확인 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->