### PR TITLE
[Feat] 세션 측정 시작 클릭 count

### DIFF
--- a/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
+++ b/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
@@ -3,7 +3,6 @@ package backend.onmoim.domain.analytics.code;
 import backend.onmoim.global.common.code.BaseErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.http.HttpStatus;
 
 @Getter

--- a/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
+++ b/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
@@ -1,0 +1,18 @@
+package backend.onmoim.domain.analytics.code;
+
+import backend.onmoim.global.common.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AnalyticsErrorCode implements BaseErrorCode {
+    ANALYTICS_NOT_FOUND(HttpStatus.NOT_FOUND,"ANALYTICS_400", "해당 Analytics 데이터를 찾을 수 없습니다."),
+    REDIS_SAVE_FAIL(HttpStatus.BAD_REQUEST,"ANALYTICS_401", "Redis에 세션 저장 실패"),
+    BAD_EVENT_ID(HttpStatus.NOT_FOUND,"ANALYTICS_402", "해당 eventID 데이터를 찾을 수 없습니다.");
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsSuccessCode.java
+++ b/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsSuccessCode.java
@@ -1,0 +1,18 @@
+package backend.onmoim.domain.analytics.code;
+
+import backend.onmoim.global.common.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AnalyticsSuccessCode implements BaseSuccessCode {
+    REQUEST_OK(HttpStatus.OK,
+            "SESSION_200",
+            "세션이 성공적으로 처리되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -1,0 +1,38 @@
+package backend.onmoim.domain.analytics.controller;
+
+import backend.onmoim.domain.analytics.code.AnalyticsSuccessCode;
+import backend.onmoim.domain.analytics.converter.AnalyticsConverter;
+import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
+import backend.onmoim.domain.analytics.service.AnalyticsCommandService;
+import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/analytics")
+public class AnalyticsController {
+
+    private final AnalyticsCommandService analyticsCommendService;
+
+    @PostMapping("/{eventId}/session")
+    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user, @PathVariable Long eventId)
+    {
+        Long userId=user.getId();
+        String sessionId =analyticsCommendService.sessionEnter(userId,eventId);
+        analyticsCommendService.enterCount(eventId);
+
+        return ApiResponse.onSuccess(
+                AnalyticsSuccessCode.REQUEST_OK,
+                AnalyticsConverter.toSessionStartDTO(sessionId)
+        );
+    }
+}
+
+
+

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -24,8 +24,9 @@ public class AnalyticsController {
     public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user, @PathVariable Long eventId)
     {
         Long userId=user.getId();
-        String sessionId =analyticsCommendService.sessionEnter(userId,eventId);
         analyticsCommendService.enterCount(eventId);
+        String sessionId =analyticsCommendService.sessionEnter(userId,eventId);
+
 
         return ApiResponse.onSuccess(
                 AnalyticsSuccessCode.REQUEST_OK,

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
@@ -1,0 +1,18 @@
+package backend.onmoim.domain.analytics.controller;
+
+import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
+import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
+import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+@Tag(name = "Event 통계 API", description = "통계 관련 API")
+public interface AnalyticsControllerDocs {
+    @Operation(summary = "입장시간 기록 및 카운트", description = "입장 시간을 기록하고 click 수를 카운트합니다.")
+    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user, @PathVariable Long eventId);
+}

--- a/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
+++ b/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
@@ -1,0 +1,14 @@
+package backend.onmoim.domain.analytics.converter;
+
+import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
+
+public class AnalyticsConverter {
+
+    public static AnalyticsResDto.SessionStartResDto toSessionStartDTO(
+            String sessionId
+    ){
+        return AnalyticsResDto.SessionStartResDto.builder()
+                .sessionId(sessionId)
+                .build();
+    }
+}

--- a/src/main/java/backend/onmoim/domain/analytics/dto/req/AnalyticsReqDto.java
+++ b/src/main/java/backend/onmoim/domain/analytics/dto/req/AnalyticsReqDto.java
@@ -1,0 +1,6 @@
+package backend.onmoim.domain.analytics.dto.req;
+
+public class AnalyticsReqDto {
+
+
+}

--- a/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
+++ b/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
@@ -1,0 +1,8 @@
+package backend.onmoim.domain.analytics.dto.res;
+
+import lombok.Builder;
+
+public class AnalyticsResDto {
+    @Builder
+    public record SessionStartResDto(String sessionId){}
+}

--- a/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
+++ b/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
@@ -19,13 +19,14 @@ public class Analytics {
     @Column(nullable=false)
     private LocalDate date;
 
+    @Version
     @Column(nullable = false)
     private int clickCount;
 
     @Column(nullable = false)
     private long avgSessionTimeSec;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
 

--- a/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
+++ b/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
@@ -18,8 +18,7 @@ public class Analytics {
 
     @Column(nullable=false)
     private LocalDate date;
-
-    @Version
+    
     @Column(nullable = false)
     private int clickCount;
 

--- a/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
+++ b/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
@@ -1,0 +1,35 @@
+package backend.onmoim.domain.analytics.entity;
+
+import backend.onmoim.domain.event.entity.Event;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access=AccessLevel.PROTECTED)
+public class Analytics {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long analyticsId;
+
+    @Column(nullable=false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private int clickCount;
+
+    @Column(nullable = false)
+    private long avgSessionTimeSec;
+
+    @ManyToOne
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    public void incrementClickCount() {
+        this.clickCount += 1;
+    }
+}

--- a/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
+++ b/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
@@ -2,6 +2,7 @@ package backend.onmoim.domain.analytics.repository;
 
 import backend.onmoim.domain.analytics.entity.Analytics;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,8 @@ public interface AnalyticsRespository extends JpaRepository<Analytics,Long> {
     @Query("SELECT a FROM Analytics a WHERE a.event.id = :eventId AND a.date = :date")
     Optional<Analytics> findByEventIdAndDate(@Param("eventId") Long eventId,
                                              @Param("date") LocalDate date);
+
+    @Modifying
+    @Query("UPDATE Analytics a SET a.clickCount = a.clickCount + 1 WHERE a.event.id = :eventId AND a.date = :date")
+    int incrementClickCount(@Param("eventId") Long eventId, @Param("date") LocalDate date);
 }

--- a/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
+++ b/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
@@ -1,0 +1,17 @@
+package backend.onmoim.domain.analytics.repository;
+
+import backend.onmoim.domain.analytics.entity.Analytics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface AnalyticsRespository extends JpaRepository<Analytics,Long> {
+    @Query("SELECT a FROM Analytics a WHERE a.event.id = :eventId AND a.date = :date")
+    Optional<Analytics> findByEventIdAndDate(@Param("eventId") Long eventId,
+                                             @Param("date") LocalDate date);
+}

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -6,9 +6,10 @@ import backend.onmoim.domain.analytics.repository.AnalyticsRespository;
 import backend.onmoim.global.common.exception.GeneralException;
 import backend.onmoim.global.common.session.RedisSessionTracker;
 import jakarta.persistence.OptimisticLockException;
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
@@ -18,7 +19,7 @@ import java.time.LocalDate;
 public class AnalyticsCommandService {
 
     private final RedisSessionTracker redisSessionTracker;
-    private final AnalyticsRespository analyticsRespoitory;
+    private final AnalyticsRespository analyticsRepository;
 
     public String sessionEnter(Long userId,Long eventId){
         String sessionId=redisSessionTracker.enter(userId,eventId);
@@ -29,22 +30,9 @@ public class AnalyticsCommandService {
 
     public void enterCount(Long eventId){
         LocalDate today = LocalDate.now();
-        int retries = 5;
-
-        while(retries>0) {
-            try {
-                Analytics analytics = analyticsRespoitory.findByEventIdAndDate(eventId, today)
-                        .orElseThrow(() -> new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID));
-
-                analytics.incrementClickCount();
-
-                analyticsRespoitory.save(analytics);
-                break;
-            }
-            catch(OptimisticLockException e){
-                retries--;
-                if(retries == 0) throw e;
-            }
+        int updated = analyticsRepository.incrementClickCount(eventId, today);
+        if (updated == 0) {
+            throw new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID);
         }
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -1,0 +1,36 @@
+package backend.onmoim.domain.analytics.service;
+
+import backend.onmoim.domain.analytics.code.AnalyticsErrorCode;
+import backend.onmoim.domain.analytics.entity.Analytics;
+import backend.onmoim.domain.analytics.repository.AnalyticsRespository;
+import backend.onmoim.global.common.exception.GeneralException;
+import backend.onmoim.global.common.session.RedisSessionTracker;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class AnalyticsCommandService {
+
+    private final RedisSessionTracker redisSessionTracker;
+    private final AnalyticsRespository analyticsRespoitory;
+
+    public String sessionEnter(Long userId,Long eventId){
+        String sessionId=redisSessionTracker.enter(userId,eventId);
+
+        return sessionId;
+    }
+
+
+    public void enterCount(Long eventId){
+        LocalDate today = LocalDate.now();
+        Analytics analytics = analyticsRespoitory.findByEventIdAndDate(eventId, today)
+                .orElseThrow(() -> new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID));
+
+        analytics.incrementClickCount();
+    }
+}

--- a/src/main/java/backend/onmoim/domain/event/entity/Event.java
+++ b/src/main/java/backend/onmoim/domain/event/entity/Event.java
@@ -1,8 +1,11 @@
 package backend.onmoim.domain.event.entity;
 
+import backend.onmoim.domain.analytics.entity.Analytics;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -26,4 +29,7 @@ public class Event {
 
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    @OneToMany(mappedBy = "event")
+    private List<Analytics> analytics = new ArrayList<>();
 }

--- a/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
+++ b/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
@@ -1,4 +1,6 @@
 package backend.onmoim.global.common.session;
+import backend.onmoim.domain.analytics.code.AnalyticsErrorCode;
+import backend.onmoim.global.common.exception.GeneralException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AllArgsConstructor;
@@ -36,7 +38,7 @@ public class RedisSessionTracker {
            String json = objectMapper.writeValueAsString(data);
            redisTemplate.opsForValue().set(KEY_PREFIX + sessionId, json, TTL);
        } catch (JsonProcessingException e) {
-           throw new RuntimeException("Redis 저장 실패", e);
+           throw new GeneralException(AnalyticsErrorCode.REDIS_SAVE_FAIL);
        }
 
        return sessionId;

--- a/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
+++ b/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
@@ -1,0 +1,44 @@
+package backend.onmoim.global.common.session;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Component
+@RequiredArgsConstructor
+public class RedisSessionTracker {
+   private static final Duration TTL = Duration.ofMinutes(50);
+   private static final String KEY_PREFIX = "session:enter:";
+   private final ObjectMapper objectMapper;
+   private final RedisTemplate<String,String> redisTemplate;
+
+   @Data
+   @AllArgsConstructor
+   static class SessionData{
+       private Long userId;
+       private Long eventId;
+       private LocalDateTime enterTime;
+   }
+
+   public String enter(Long userId,Long eventId){
+       String sessionId = UUID.randomUUID().toString();
+       SessionData data = new SessionData(userId,eventId,LocalDateTime.now());
+
+       try {
+           String json = objectMapper.writeValueAsString(data);
+           redisTemplate.opsForValue().set(KEY_PREFIX + sessionId, json, TTL);
+       } catch (JsonProcessingException e) {
+           throw new RuntimeException("Redis 저장 실패", e);
+       }
+
+       return sessionId;
+   }
+}

--- a/src/main/java/backend/onmoim/global/config/RedisConfig.java
+++ b/src/main/java/backend/onmoim/global/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package backend.onmoim.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -22,5 +25,13 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // LocalDateTime 직렬화 지원
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO 형식 사용
+        return mapper;
     }
 }

--- a/src/main/java/backend/onmoim/global/config/SecurityConfig.java
+++ b/src/main/java/backend/onmoim/global/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
     };
 
     private final String[] test_uris = {
-            "/api/v1/test/**"
+            "/api/v1/test/**",
+            "/api/v1/auth/email/**"
     };
 
     private final String[] refresh_uris = {

--- a/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
+++ b/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
@@ -39,7 +39,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             "/v3/api-docs/**", "/webjars/**", "/swagger-resources/configuration/ui",
             "/api/v1/users/signup", "/api/v1/users/login",
             "/api/v1/auth/refresh",
-            "/api/v1/test/healthcheck"
+            "/api/v1/test/healthcheck","/api/v1/auth/email/**"
     };
 
     // Swagger 경로는 필터를 거치지 않도록 우회

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect # Hibernate에서 사용할 MySQL 방언(dialect) 설정
     show-sql: true # 실행된 SQL 쿼리를 콘솔에 출력할지 여부 설정
     hibernate:
-      ddl-auto: update # 애플리케이션 실행 시 데이터베이스 스키마의 상태를 설정
+      ddl-auto: none # 애플리케이션 실행 시 데이터베이스 스키마의 상태를 설정
     properties:
       hibernate:
         format_sql: true # 출력되는 SQL 쿼리를 보기 좋게 포맷팅

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect # Hibernate에서 사용할 MySQL 방언(dialect) 설정
     show-sql: true # 실행된 SQL 쿼리를 콘솔에 출력할지 여부 설정
     hibernate:
-      ddl-auto: update # 애플리케이션 실행 시 데이터베이스 스키마의 상태를 설정
+      ddl-auto: none # 애플리케이션 실행 시 데이터베이스 스키마의 상태를 설정
     properties:
       hibernate:
         format_sql: true # 출력되는 SQL 쿼리를 보기 좋게 포맷팅

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect # Hibernate에서 사용할 MySQL 방언(dialect) 설정
     show-sql: true # 실행된 SQL 쿼리를 콘솔에 출력할지 여부 설정
     hibernate:
-      ddl-auto: none # 애플리케이션 실행 시 데이터베이스 스키마의 상태를 설정
+      ddl-auto: update # 애플리케이션 실행 시 데이터베이스 스키마의 상태를 설정
     properties:
       hibernate:
         format_sql: true # 출력되는 SQL 쿼리를 보기 좋게 포맷팅


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
<img width="954" height="460" alt="스크린샷 2026-01-30 131546" src="https://github.com/user-attachments/assets/7c0b03aa-e2a5-46c2-9346-cb8c329d82ef" />


들어온 시간을 redis 에 적어두도록 했습니다. TTL은 50분으로 했습니다 아마도 TTL 넘기는 애들은 통계에 의미가 없다고 생각해서 
통계에서 빼버릴 생각이긴 합니다.
세션아이디는 그냥 무작위로 생성되게 해놨습니다


<img width="455" height="139" alt="스크린샷 2026-01-30 131537" src="https://github.com/user-attachments/assets/135cc7f2-dff4-4de1-945f-4fb33a89324e" />


로컬 redis 에서 잘 들어갔나 확인 해보았는데 이상없었습니다


<img width="638" height="486" alt="스크린샷 2026-01-30 134614" src="https://github.com/user-attachments/assets/8f2a8b32-ad76-4e52-bda3-0c9eeac8c044" />


eventId를 이상한 값으로 했을 경우 대비했습니다.
---

## 🔗 관련 이슈
- closes #1

---

## 💡 추가 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이벤트 분석 기능 추가 - 이벤트별 방문 수 및 세션 시간 추적
  * 사용자 세션 시작 API 엔드포인트 추가
  * Redis 기반 세션 저장소 구현으로 사용자 세션 관리 기능 개선
  * 이벤트 진입 시 클릭 수 자동 집계

* **보안 개선**
  * 이메일 인증 관련 엔드포인트에 대한 공개 접근 허용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->