### PR TITLE
[Refactor]인증코드 전송시 회원가입이 되어있는지 아닌지 확인 하도록 ResDTO 수정

### DIFF
--- a/src/main/java/backend/onmoim/domain/auth/controller/AuthController.java
+++ b/src/main/java/backend/onmoim/domain/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package backend.onmoim.domain.auth.controller;
 
-import backend.onmoim.domain.auth.dto.RotateTokenResponseDTO;
+import backend.onmoim.domain.auth.dto.response.RotateTokenResponseDTO;
 import backend.onmoim.domain.auth.service.AuthService;
 import backend.onmoim.global.common.ApiResponse;
 import backend.onmoim.global.common.code.GeneralSuccessCode;

--- a/src/main/java/backend/onmoim/domain/auth/converter/EmailAuthConverter.java
+++ b/src/main/java/backend/onmoim/domain/auth/converter/EmailAuthConverter.java
@@ -13,11 +13,12 @@ public class EmailAuthConverter {
                 .isUsed(false)
                 .build();
     }
-    public static EmailAuthResponseDTO.VerificationResultDTO toResultDTO(String email, Long expireSeconds) {
+    public static EmailAuthResponseDTO.VerificationResultDTO toResultDTO(String email, Long expireSeconds,boolean isRegistered) {
         return new EmailAuthResponseDTO.VerificationResultDTO(
                 email,
                 LocalDateTime.now(),
-                expireSeconds
+                expireSeconds,
+                isRegistered
         );
     }
 }

--- a/src/main/java/backend/onmoim/domain/auth/dto/response/EmailAuthResponseDTO.java
+++ b/src/main/java/backend/onmoim/domain/auth/dto/response/EmailAuthResponseDTO.java
@@ -10,7 +10,8 @@ public class EmailAuthResponseDTO {
     public record VerificationResultDTO(
             String email,
             LocalDateTime sentAt,
-            Long expiresInSeconds
+            Long expiresInSeconds,
+            boolean isRegistered
     ) {}
 
     public record VerifyResponseDTO(

--- a/src/main/java/backend/onmoim/domain/auth/dto/response/RotateTokenResponseDTO.java
+++ b/src/main/java/backend/onmoim/domain/auth/dto/response/RotateTokenResponseDTO.java
@@ -1,4 +1,4 @@
-package backend.onmoim.domain.auth.dto;
+package backend.onmoim.domain.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/backend/onmoim/domain/auth/service/AuthService.java
+++ b/src/main/java/backend/onmoim/domain/auth/service/AuthService.java
@@ -1,6 +1,6 @@
 package backend.onmoim.domain.auth.service;
 
-import backend.onmoim.domain.auth.dto.RotateTokenResponseDTO;
+import backend.onmoim.domain.auth.dto.response.RotateTokenResponseDTO;
 import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.domain.user.repository.UserQueryRepository;
 import backend.onmoim.global.common.code.GeneralErrorCode;

--- a/src/main/java/backend/onmoim/domain/auth/service/command/EmailAuthCommandServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/auth/service/command/EmailAuthCommandServiceImpl.java
@@ -80,10 +80,11 @@ class EmailAuthCommandServiceImpl implements EmailAuthCommandService {
         }
 
 
-        boolean isRegistered = userQueryRepository.existsByEmail(request.email());
-
         // 봇 방지 검증 (Turnstile)
         verifyTurnstile(request.turnstileToken());
+
+        //회원유무 조회
+        boolean isRegistered = userQueryRepository.existsByEmail(request.email());
 
         // 인증 정보 DB 저장
         String code = String.format("%06d", secureRandom.nextInt(1_000_000));

--- a/src/main/java/backend/onmoim/domain/user/repository/UserQueryRepository.java
+++ b/src/main/java/backend/onmoim/domain/user/repository/UserQueryRepository.java
@@ -11,4 +11,5 @@ public interface UserQueryRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
     Optional<User> findByEmail(String email);
     Boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/backend/onmoim/global/config/SecurityConfig.java
+++ b/src/main/java/backend/onmoim/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
     };
 
     private final String[] login_uris = {
-            "/api/v1/users/login", "/api/v1/users/signup"
+            "/api/v1/users/login", "/api/v1/users/signup","/api/v1/auth/email/**"
     };
 
     private final String[] test_uris = {

--- a/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
+++ b/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
@@ -38,6 +38,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**",
             "/v3/api-docs/**", "/webjars/**", "/swagger-resources/configuration/ui",
             "/api/v1/users/signup", "/api/v1/users/login",
+            "/api/v1/auth/email/**",
             "/api/v1/auth/refresh",
             "/api/v1/test/healthcheck"
     };


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
인증코드 전송시 회원가입이 되어있는지 아닌지 확인 하도록 ResDTO 수정

회원가입 안됐을때
<img width="1640" height="1405" alt="스크린샷 2026-01-30 215200" src="https://github.com/user-attachments/assets/ee2c7e1b-1f79-4660-9188-942a876b09b4" />

회원가입 됐을때
<img width="1663" height="961" alt="스크린샷 2026-01-30 215404" src="https://github.com/user-attachments/assets/f755dab4-24a0-4917-afe3-a334edcc8765" />

로그인이 안되있어도 인증코드 전송 및 검증 할 수 있도록 securityConfig, JwtAuthFilter의 허용 경로에 이메일 api추가
---

## 🔗 관련 이슈
- closes #18
---

## 💡 추가 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일 인증 응답에 사용자의 가입 여부(isRegistered) 정보 추가
  * 이메일 인증 과정에서 사용자의 이메일 존재 여부를 확인하는 검사 추가

* **개선 사항**
  * 이메일 인증 관련 엔드포인트에 대한 접근 제한 완화(인증 필터 예외 처리)로 인증 흐름 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->