### PR TITLE
[Feat] 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/backend/onmoim/domain/auth/service/AuthService.java
+++ b/src/main/java/backend/onmoim/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package backend.onmoim.domain.auth.service;
 
 import backend.onmoim.domain.auth.dto.RotateTokenResponseDTO;
 import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.domain.user.enums.Status;
 import backend.onmoim.domain.user.repository.UserQueryRepository;
 import backend.onmoim.global.common.code.GeneralErrorCode;
 import backend.onmoim.global.common.exception.GeneralException;
@@ -10,6 +11,7 @@ import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +48,11 @@ public class AuthService {
         Long userId = jwtUtil.getId(refreshToken);
         User user = userQueryRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.MEMBER_NOT_FOUND));
+
+        if (user.getStatus() != Status.ACTIVE) {
+            SecurityContextHolder.clearContext();
+            throw new GeneralException(GeneralErrorCode.USER_INACTIVE);
+        }
 
         // 새 access + 새 refresh 생성
         String newAccessToken = jwtUtil.createAccessToken(user);

--- a/src/main/java/backend/onmoim/domain/user/controller/UserController.java
+++ b/src/main/java/backend/onmoim/domain/user/controller/UserController.java
@@ -4,16 +4,16 @@ import backend.onmoim.domain.user.dto.req.LoginRequestDTO;
 import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
 import backend.onmoim.domain.user.dto.res.LoginResponseDTO;
 import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.domain.user.service.UserCommandService;
 import backend.onmoim.domain.user.service.UserQueryService;
 import backend.onmoim.global.common.ApiResponse;
 import backend.onmoim.global.common.code.GeneralSuccessCode;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserControllerDocs {
 
     private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
 
 
     @Override
@@ -36,5 +37,14 @@ public class UserController implements UserControllerDocs {
             HttpServletResponse response
     ){
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, userQueryService.login(dto,response));
+    }
+
+    @Override
+    @DeleteMapping("/")
+    public ApiResponse<Void> withdraw(
+            @AuthenticationPrincipal User user
+    ) {
+        userCommandService.withdraw(user.getId());
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK,null);
     }
 }

--- a/src/main/java/backend/onmoim/domain/user/controller/UserController.java
+++ b/src/main/java/backend/onmoim/domain/user/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController implements UserControllerDocs {
     }
 
     @Override
-    @DeleteMapping("/")
+    @DeleteMapping("")
     public ApiResponse<Void> withdraw(
             @AuthenticationPrincipal User user
     ) {

--- a/src/main/java/backend/onmoim/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/backend/onmoim/domain/user/controller/UserControllerDocs.java
@@ -4,11 +4,13 @@ import backend.onmoim.domain.user.dto.req.LoginRequestDTO;
 import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
 import backend.onmoim.domain.user.dto.res.LoginResponseDTO;
 import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "사용자 API", description = "사용자 관련 API")
@@ -23,5 +25,10 @@ public interface UserControllerDocs {
     ApiResponse<LoginResponseDTO.LoginDTO> login(
             @RequestBody @Valid LoginRequestDTO.LoginDTO dto,
             HttpServletResponse response
+    );
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 처리합니다.")
+    ApiResponse<Void> withdraw(
+            @AuthenticationPrincipal User user
     );
 }

--- a/src/main/java/backend/onmoim/domain/user/entity/User.java
+++ b/src/main/java/backend/onmoim/domain/user/entity/User.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Entity
 @AllArgsConstructor
@@ -43,6 +45,14 @@ public class User extends BaseEntity {
 
     @Column(name = "linkedin_id", length = 255)
     private String linkedinId;
+
+    @Column(name = "deleted_At")
+    private LocalDateTime deletedAt;
+
+    public void withdraw() {
+        this.status = Status.INACTIVE;
+        this.deletedAt = LocalDateTime.now();
+    }
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, optional = true)
     @JoinColumn(name = "profile_image_id")

--- a/src/main/java/backend/onmoim/domain/user/service/UserCommandService.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserCommandService.java
@@ -1,0 +1,5 @@
+package backend.onmoim.domain.user.service;
+
+public interface UserCommandService {
+    void withdraw(Long userId);  // 비밀번호 확인 후 탈퇴
+}

--- a/src/main/java/backend/onmoim/domain/user/service/UserCommandService.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserCommandService.java
@@ -1,5 +1,5 @@
 package backend.onmoim.domain.user.service;
 
 public interface UserCommandService {
-    void withdraw(Long userId);  // 비밀번호 확인 후 탈퇴
+    void withdraw(Long userId);
 }

--- a/src/main/java/backend/onmoim/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,54 @@
+package backend.onmoim.domain.user.service;
+
+import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.domain.user.enums.Status;
+import backend.onmoim.domain.user.repository.UserRepository;
+import backend.onmoim.global.common.code.GeneralErrorCode;
+import backend.onmoim.global.common.exception.GeneralException;
+import backend.onmoim.global.utils.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static reactor.netty.http.HttpConnectionLiveness.log;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    @Transactional
+    public void withdraw(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.MEMBER_NOT_FOUND));
+
+        if (user.getStatus() != Status.ACTIVE) {
+            throw new GeneralException(GeneralErrorCode.USER_INACTIVE);
+        }
+
+        user.withdraw();
+
+        // Refresh 토큰 무효화
+        jwtUtil.invalidateRefreshToken(userId);
+
+        // 7일 재가입 차단 (Redis)
+        String banKey = "ban:email:" + user.getEmail();
+        redisTemplate.opsForValue().set(
+                banKey,
+                "withdrawn:" + LocalDateTime.now(),
+                Duration.ofDays(7)
+        );
+
+        log.info("사용자ID {} 탈퇴 처리됨, 7일간 재가입 차단 ({}까지)",
+                userId, LocalDateTime.now().plusDays(7));
+    }
+}

--- a/src/main/java/backend/onmoim/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserCommandServiceImpl.java
@@ -7,6 +7,7 @@ import backend.onmoim.global.common.code.GeneralErrorCode;
 import backend.onmoim.global.common.exception.GeneralException;
 import backend.onmoim.global.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-import static reactor.netty.http.HttpConnectionLiveness.log;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService {

--- a/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
@@ -17,7 +17,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -57,6 +56,8 @@ public class UserQueryServiceImpl implements UserQueryService{
         String refreshToken = jwtUtil.createRefreshToken(user);
 
         jwtUtil.setRefreshTokenCookie(response, refreshToken);
+        String refreshKey = "refresh:token:" + user.getId();
+        jwtUtil.storeRefreshToken(refreshKey, refreshToken);
 
         // DTO 조립
         return UserConverter.toLoginDTO(user, accessToken);

--- a/src/main/java/backend/onmoim/global/config/SecurityConfig.java
+++ b/src/main/java/backend/onmoim/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
     };
 
     private final String[] refresh_uris = {
-            "/api/v1/auth/refresh"
+            "/api/v1/auth/**"
     };
 
 

--- a/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
+++ b/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
@@ -40,7 +40,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             "/v3/api-docs/**", "/webjars/**", "/swagger-resources/configuration/ui",
             "/api/v1/users/signup", "/api/v1/users/login",
             "/api/v1/auth/refresh",
-            "/api/v1/test/healthcheck"
+            "/api/v1/test/healthcheck",
+            "/api/v1/auth/**"
     };
 
     // Swagger 경로는 필터를 거치지 않도록 우회

--- a/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
+++ b/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
@@ -1,6 +1,7 @@
 package backend.onmoim.global.security;
 
 import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.domain.user.enums.Status;
 import backend.onmoim.domain.user.repository.UserQueryRepository;
 import backend.onmoim.global.common.ApiResponse;
 import backend.onmoim.global.common.code.BaseErrorCode;
@@ -71,7 +72,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
             }
 
-
             if (!jwtUtil.isValidAccessToken(accessToken)) {
                 throw new GeneralException(GeneralErrorCode.INVALID_TOKEN);
             }
@@ -79,6 +79,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
             User user = userQueryRepository.findById(userId)
                     .orElseThrow(() -> new GeneralException(GeneralErrorCode.MEMBER_NOT_FOUND));
+
+            if (user.getStatus() != Status.ACTIVE) {
+                SecurityContextHolder.clearContext();
+                throw new GeneralException(GeneralErrorCode.USER_INACTIVE);
+            }
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(user, null, new ArrayList<>());

--- a/src/main/java/backend/onmoim/global/utils/JwtUtil.java
+++ b/src/main/java/backend/onmoim/global/utils/JwtUtil.java
@@ -163,4 +163,7 @@ public class JwtUtil {
         redisTemplate.delete(refreshKey);
     }
 
+    public void storeRefreshToken(String key, String refreshToken) {
+        redisTemplate.opsForValue().set(key, refreshToken, refreshExpiration);
+    }
 }

--- a/src/main/java/backend/onmoim/global/utils/JwtUtil.java
+++ b/src/main/java/backend/onmoim/global/utils/JwtUtil.java
@@ -4,7 +4,6 @@ import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.global.common.code.GeneralErrorCode;
 import backend.onmoim.global.common.exception.GeneralException;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -12,6 +11,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -26,15 +27,18 @@ public class JwtUtil {
     private final SecretKey secretKey;
     private final Duration accessExpiration;
     private final Duration refreshExpiration;
+    private final RedisTemplate<String, String> redisTemplate;
+
 
     public JwtUtil(
             @Value("${jwt.token.secretKey}") String secret,
             @Value("${jwt.token.expiration.access}") Long accessExpiration,
-            @Value("${jwt.token.expiration.refresh}" ) Long refreshExpiration
+            @Value("${jwt.token.expiration.refresh}" ) Long refreshExpiration, StringRedisTemplate redisTemplate
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessExpiration = Duration.ofMillis(accessExpiration);
         this.refreshExpiration = Duration.ofMillis(refreshExpiration);
+        this.redisTemplate = redisTemplate;
     }
 
     // AccessToken 생성
@@ -152,4 +156,11 @@ public class JwtUtil {
             return false;
         }
     }
+
+    // refresh token 무효화
+    public void invalidateRefreshToken(Long userId) {
+        String refreshKey = "refresh:token:" + userId;
+        redisTemplate.delete(refreshKey);
+    }
+
 }


### PR DESCRIPTION
- 탈퇴 시 7일 재가입 차단

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- 소프트 딜리트: status=INACTIVE, deleted_at 컬럼 추가
- Refresh 토큰 무효화: Redis 키 삭제
- 7일 재가입 차단: Redis ban:email:{email} TTL 7일
- INACTIVE 사용자 차단: JwtAuthFilter 상태 검증 강화

<img width="957" height="725" alt="스크린샷 2026-01-30 오후 9 47 57" src="https://github.com/user-attachments/assets/913af4be-3d7b-4e98-9a82-4e9f755b8d5d" />

---

## 🔗 관련 이슈
- closes #17

---

## 💡 추가 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 탈퇴 API 추가: 인증된 사용자가 계정을 탈퇴할 수 있습니다.
  * 탈퇴 시 리프레시 토큰이 즉시 무효화되고, 재가입 방지용 차단 정보가 7일간 적용됩니다.
  * 로그인 시 리프레시 토큰을 저장하여 서버에서 관리합니다.

* **보안 개선**
  * 비활성(탈퇴 등) 계정의 토큰 갱신 및 요청을 차단하도록 인증 흐름을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->