### PR TITLE
[Feat] 회원 조회 기능 구현

### DIFF
--- a/src/main/java/backend/onmoim/domain/user/controller/UserController.java
+++ b/src/main/java/backend/onmoim/domain/user/controller/UserController.java
@@ -4,16 +4,16 @@ import backend.onmoim.domain.user.dto.req.LoginRequestDTO;
 import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
 import backend.onmoim.domain.user.dto.res.LoginResponseDTO;
 import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.dto.res.UserProfileDTO;
+import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.domain.user.service.UserQueryService;
 import backend.onmoim.global.common.ApiResponse;
 import backend.onmoim.global.common.code.GeneralSuccessCode;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,5 +36,12 @@ public class UserController implements UserControllerDocs {
             HttpServletResponse response
     ){
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, userQueryService.login(dto,response));
+    }
+
+    @Override
+    @GetMapping("")
+    public ApiResponse<UserProfileDTO> getMyProfile(
+            @AuthenticationPrincipal User user) {
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, userQueryService.getMyProfile(user));  // User 전달
     }
 }

--- a/src/main/java/backend/onmoim/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/backend/onmoim/domain/user/controller/UserControllerDocs.java
@@ -4,11 +4,14 @@ import backend.onmoim.domain.user.dto.req.LoginRequestDTO;
 import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
 import backend.onmoim.domain.user.dto.res.LoginResponseDTO;
 import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.dto.res.UserProfileDTO;
+import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "사용자 API", description = "사용자 관련 API")
@@ -24,4 +27,7 @@ public interface UserControllerDocs {
             @RequestBody @Valid LoginRequestDTO.LoginDTO dto,
             HttpServletResponse response
     );
+
+    @Operation(summary = "회원 조회", description = "가입된 사용자 정보를 조회합니다.")
+    ApiResponse<UserProfileDTO> getMyProfile(@AuthenticationPrincipal User user);
 }

--- a/src/main/java/backend/onmoim/domain/user/converter/UserConverter.java
+++ b/src/main/java/backend/onmoim/domain/user/converter/UserConverter.java
@@ -2,6 +2,7 @@ package backend.onmoim.domain.user.converter;
 
 import backend.onmoim.domain.user.dto.res.LoginResponseDTO;
 import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.dto.res.UserProfileDTO;
 import backend.onmoim.domain.user.entity.User;
 
 public class UserConverter {
@@ -21,4 +22,17 @@ public class UserConverter {
                 .accessToken(accessToken)
                 .build();
     }
+
+    public static UserProfileDTO toProfileDTO(User user) {
+        return UserProfileDTO.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .introduction(user.getIntroduction())
+                .instagramId(user.getInstagramId())
+                .twitterId(user.getTwitterId())
+                .linkedinId(user.getLinkedinId())
+                .build();
+    }
+
 }

--- a/src/main/java/backend/onmoim/domain/user/dto/res/UserProfileDTO.java
+++ b/src/main/java/backend/onmoim/domain/user/dto/res/UserProfileDTO.java
@@ -1,0 +1,16 @@
+package backend.onmoim.domain.user.dto.res;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserProfileDTO {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String introduction;
+    private String instagramId;
+    private String twitterId;
+    private String linkedinId;
+}

--- a/src/main/java/backend/onmoim/domain/user/service/UserQueryService.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserQueryService.java
@@ -4,9 +4,12 @@ import backend.onmoim.domain.user.dto.req.LoginRequestDTO;
 import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
 import backend.onmoim.domain.user.dto.res.LoginResponseDTO;
 import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.dto.res.UserProfileDTO;
+import backend.onmoim.domain.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 public interface UserQueryService {
     LoginResponseDTO.LoginDTO login(@Valid LoginRequestDTO.LoginDTO dto, HttpServletResponse response);
@@ -14,4 +17,6 @@ public interface UserQueryService {
     // 회원가입
     @Transactional
     SignUpResponseDTO.SignUpDTO signup(SignUpRequestDTO.SignUpDTO dto);
+
+    UserProfileDTO getMyProfile(@AuthenticationPrincipal User user);
 }

--- a/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
@@ -9,6 +9,7 @@ import backend.onmoim.domain.user.dto.req.LoginRequestDTO;
 import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
 import backend.onmoim.domain.user.dto.res.LoginResponseDTO;
 import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
+import backend.onmoim.domain.user.dto.res.UserProfileDTO;
 import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.domain.user.enums.Status;
 import backend.onmoim.domain.user.repository.UserQueryRepository;
@@ -18,11 +19,12 @@ import backend.onmoim.global.common.exception.GeneralException;
 import backend.onmoim.global.utils.JwtUtil;
 import backend.onmoim.global.utils.RandomNicknameGenerator;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -93,4 +95,12 @@ public class UserQueryServiceImpl implements UserQueryService{
         }
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public UserProfileDTO getMyProfile(@AuthenticationPrincipal User user) {
+        if (user.getStatus() != Status.ACTIVE) {
+            throw new GeneralException(GeneralErrorCode.USER_INACTIVE);
+        }
+        return UserConverter.toProfileDTO(user);
+    }
 }

--- a/src/main/java/backend/onmoim/global/config/SecurityConfig.java
+++ b/src/main/java/backend/onmoim/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
     };
 
     private final String[] login_uris = {
-            "/api/v1/users/login", "/api/v1/users/signup","/api/v1/auth/email/**"
+            "/api/v1/users/login", "/api/v1/users/signup"
     };
 
     private final String[] test_uris = {

--- a/src/main/java/backend/onmoim/global/config/SecurityConfig.java
+++ b/src/main/java/backend/onmoim/global/config/SecurityConfig.java
@@ -33,8 +33,7 @@ public class SecurityConfig {
     };
 
     private final String[] test_uris = {
-            "/api/v1/test/**",
-            "/api/v1/auth/email/**"
+            "/api/v1/test/**"
     };
 
     private final String[] auth_uris = {

--- a/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
+++ b/src/main/java/backend/onmoim/global/security/JwtAuthFilter.java
@@ -69,7 +69,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         try {
             String accessToken = resolveToken(request);
             if (accessToken == null) {
-                throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+                log.warn("No access token provided for path: {}", request.getRequestURI());
+                filterChain.doFilter(request, response);
+                return;
             }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,7 @@ jwt:
     expiration:
       access: 3600000
       refresh: 604800000
+
+logging:
+  level:
+    backend.onmoim.global.security.JwtAuthFilter: DEBUG


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## 작업 내용
- 회원 프로필 조회 API 구현 (이미지 조회 제외)
- JWT 인증 기반 본인 정보 조회 기능 추가
- UserProfileDTO 응답 객체 생성
- UserConverter에 DTO 변환 로직 추가

**주요 변경사항**
1. `GET /api/v1/users` - 회원 프로필 조회 API 추가
2. UserQueryService에 회원 조회 메서드 구현
3. JWT 필터에서 사용자 정보 추출 로직 개선
4. Swagger 문서화 추가
5. Security 설정 조정

**응답 정보**
- 사용자 ID
- 이메일
- 닉네임
- 소개
- 인스타 ID
- 트위터 ID
- 링크드인 ID

<img width="957" height="606" alt="스크린샷 2026-01-31 오전 1 36 51" src="https://github.com/user-attachments/assets/01695dd4-042d-4e38-9764-f48a973d5718" />

---

## 🔗 관련 이슈
- closes #22

---

## 💡 추가 사항
회원 수정 기능 구현 시 이미지 업로드 로직 추가 예정
그에 따라 조회 응답 DTO에 이미지 링크 불러오는 로직 추가 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증된 사용자가 자신의 프로필 정보(이메일, 닉네임, 소개, SNS 계정 정보)를 조회할 수 있는 새로운 프로필 조회 API 엔드포인트 추가

* **개선 사항**
  * 액세스 토큰이 없는 요청에 대한 처리 방식 개선으로 더욱 유연한 인증 흐름 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->