### PR TITLE
[Feat] 스케줄러로 00시 새로운 테이블 생성

### DIFF
--- a/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
+++ b/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum AnalyticsErrorCode implements BaseErrorCode {
     ANALYTICS_NOT_FOUND(HttpStatus.NOT_FOUND,"ANALYTICS_400", "해당 Analytics 데이터를 찾을 수 없습니다."),
     REDIS_SAVE_FAIL(HttpStatus.BAD_REQUEST,"ANALYTICS_401", "Redis에 세션 저장 실패"),
-    BAD_EVENT_ID(HttpStatus.NOT_FOUND,"ANALYTICS_402", "해당 eventID 데이터를 찾을 수 없습니다.");
+    BAD_EVENT_ID(HttpStatus.NOT_FOUND,"ANALYTICS_402", "해당 eventID 데이터를 찾을 수 없습니다."),
+    REDIS_NOT_FOUND(HttpStatus.NOT_FOUND,"ANALYTICS_403","SESSION에 저장되지 않는 키입니다"),
+    REDIS_DESERIALIZE_FAIL(HttpStatus.BAD_REQUEST,"ANALYTICS_405","역직렬화에 실패했습니다");
+
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -6,27 +6,42 @@ import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
 import backend.onmoim.domain.analytics.service.AnalyticsCommandService;
 import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.global.common.ApiResponse;
+import backend.onmoim.global.validation.annotation.ExistEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/analytics")
-public class AnalyticsController {
+public class AnalyticsController implements AnalyticsControllerDocs{
 
     private final AnalyticsCommandService analyticsCommendService;
 
+    @Override
     @PostMapping("/{eventId}/session")
-    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user, @PathVariable Long eventId)
+    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user,@ExistEvent @PathVariable Long eventId)
     {
         Long userId=user.getId();
-        analyticsCommendService.enterCount(eventId);
         String sessionId =analyticsCommendService.sessionEnter(userId,eventId);
 
+        return ApiResponse.onSuccess(
+                AnalyticsSuccessCode.REQUEST_OK,
+                AnalyticsConverter.toSessionStartDTO(sessionId)
+        );
+    }
+
+    @Override
+    @PostMapping("/{eventId}/sessions/{sessionId}")
+    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId)
+    {
+        analyticsCommendService.exitCount(eventId);
+        analyticsCommendService.sessionExit(eventId,sessionId);
 
         return ApiResponse.onSuccess(
                 AnalyticsSuccessCode.REQUEST_OK,

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -37,10 +37,10 @@ public class AnalyticsController implements AnalyticsControllerDocs{
     }
 
     @Override
-    @PostMapping("/{eventId}/sessions/{sessionId}")
+    @PostMapping("/{eventId}/session/{sessionId}")
     public ApiResponse<AnalyticsResDto.SessionEndResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId)
     {
-        analyticsCommendService.sessionExit(sessionId);
+        analyticsCommendService.sessionExit(sessionId,eventId);
         analyticsCommendService.exitCount(eventId);
 
         return ApiResponse.onSuccess(

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -40,8 +40,8 @@ public class AnalyticsController implements AnalyticsControllerDocs{
     @PostMapping("/{eventId}/sessions/{sessionId}")
     public ApiResponse<AnalyticsResDto.SessionEndResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId)
     {
-        analyticsCommendService.exitCount(eventId);
         analyticsCommendService.sessionExit(sessionId);
+        analyticsCommendService.exitCount(eventId);
 
         return ApiResponse.onSuccess(
                 AnalyticsSuccessCode.REQUEST_OK,

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -40,8 +40,8 @@ public class AnalyticsController implements AnalyticsControllerDocs{
     @PostMapping("/{eventId}/session/{sessionId}")
     public ApiResponse<AnalyticsResDto.SessionEndResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId)
     {
-        analyticsCommendService.sessionExit(sessionId,eventId);
         analyticsCommendService.exitCount(eventId);
+        analyticsCommendService.sessionExit(sessionId,eventId);
 
         return ApiResponse.onSuccess(
                 AnalyticsSuccessCode.REQUEST_OK,

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -38,14 +38,14 @@ public class AnalyticsController implements AnalyticsControllerDocs{
 
     @Override
     @PostMapping("/{eventId}/sessions/{sessionId}")
-    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId)
+    public ApiResponse<AnalyticsResDto.SessionEndResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId)
     {
         analyticsCommendService.exitCount(eventId);
-        analyticsCommendService.sessionExit(eventId,sessionId);
+        analyticsCommendService.sessionExit(sessionId);
 
         return ApiResponse.onSuccess(
                 AnalyticsSuccessCode.REQUEST_OK,
-                AnalyticsConverter.toSessionStartDTO(sessionId)
+                AnalyticsConverter.toSessionEndDTO(sessionId)
         );
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
@@ -1,18 +1,21 @@
 package backend.onmoim.domain.analytics.controller;
 
 import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
-import backend.onmoim.domain.user.dto.req.SignUpRequestDTO;
-import backend.onmoim.domain.user.dto.res.SignUpResponseDTO;
 import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.global.common.ApiResponse;
+import backend.onmoim.global.validation.annotation.ExistEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PostMapping;
+
+
 @Tag(name = "Event 통계 API", description = "통계 관련 API")
 public interface AnalyticsControllerDocs {
-    @Operation(summary = "입장시간 기록 및 카운트", description = "입장 시간을 기록하고 click 수를 카운트합니다.")
-    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user, @PathVariable Long eventId);
+    @Operation(summary = "입장시간 기록 및 카운트", description = "입장 시간을 기록합니다.")
+    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user,@ExistEvent @PathVariable Long eventId);
+
+    @Operation(summary = "퇴장 시간 기록 및 머문 시간 계산", description = "머문 시간을 측정하고 click 수를 카운트 합니다 평균을 계산합니다")
+    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId);
 }

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
@@ -17,5 +17,5 @@ public interface AnalyticsControllerDocs {
     public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionStart(@AuthenticationPrincipal User user,@ExistEvent @PathVariable Long eventId);
 
     @Operation(summary = "퇴장 시간 기록 및 머문 시간 계산", description = "머문 시간을 측정하고 click 수를 카운트 합니다 평균을 계산합니다")
-    public ApiResponse<AnalyticsResDto.SessionStartResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId);
+    public ApiResponse<AnalyticsResDto.SessionEndResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId);
 }

--- a/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
+++ b/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
@@ -13,11 +13,10 @@ public class AnalyticsConverter {
     }
 
     public static AnalyticsResDto.SessionEndResDto toSessionEndDTO(
-            String sessionId,Long seconds
+            String sessionId
     ){
         return AnalyticsResDto.SessionEndResDto.builder()
                 .sessionId(sessionId)
-                .seconds(seconds)
                 .build();
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
+++ b/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
@@ -11,4 +11,13 @@ public class AnalyticsConverter {
                 .sessionId(sessionId)
                 .build();
     }
+
+    public static AnalyticsResDto.SessionEndResDto toSessionEndDTO(
+            String sessionId,Long seconds
+    ){
+        return AnalyticsResDto.SessionEndResDto.builder()
+                .sessionId(sessionId)
+                .seconds(seconds)
+                .build();
+    }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
+++ b/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
@@ -5,4 +5,7 @@ import lombok.Builder;
 public class AnalyticsResDto {
     @Builder
     public record SessionStartResDto(String sessionId){}
+
+    @Builder
+    public record SessionEndResDto(String sessionId,long seconds){}
 }

--- a/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
+++ b/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
@@ -7,5 +7,5 @@ public class AnalyticsResDto {
     public record SessionStartResDto(String sessionId){}
 
     @Builder
-    public record SessionEndResDto(String sessionId,long seconds){}
+    public record SessionEndResDto(String sessionId){}
 }

--- a/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
+++ b/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
@@ -32,4 +32,5 @@ public class Analytics {
     public void incrementClickCount() {
         this.clickCount += 1;
     }
+
 }

--- a/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
+++ b/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
@@ -11,6 +11,15 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access=AccessLevel.PROTECTED)
+@Table(
+        name = "analytics",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_event_date",
+                        columnNames = {"event_id", "date"}
+                )
+        }
+)
 public class Analytics {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +35,7 @@ public class Analytics {
     private long avgSessionTimeSec;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
+    @JoinColumn(name = "event_id",nullable = false)
     private Event event;
 
     public void incrementClickCount() {

--- a/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
+++ b/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
@@ -18,7 +18,7 @@ public class Analytics {
 
     @Column(nullable=false)
     private LocalDate date;
-    
+
     @Column(nullable = false)
     private int clickCount;
 

--- a/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
+++ b/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
@@ -1,6 +1,7 @@
 package backend.onmoim.domain.analytics.repository;
 
 import backend.onmoim.domain.analytics.entity.Analytics;
+import backend.onmoim.domain.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -27,4 +28,6 @@ public interface AnalyticsRespository extends JpaRepository<Analytics,Long> {
     int updateAverageDuration(@Param("eventId") Long eventId,
                               @Param("date") LocalDate date,
                               @Param("sessionTime") long sessionTime);
+
+    boolean existsByEventAndDate(Event event, LocalDate date);
 }

--- a/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
+++ b/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
@@ -19,4 +19,13 @@ public interface AnalyticsRespository extends JpaRepository<Analytics,Long> {
     @Modifying
     @Query("UPDATE Analytics a SET a.clickCount = a.clickCount + 1 WHERE a.event.id = :eventId AND a.date = :date")
     int incrementClickCount(@Param("eventId") Long eventId, @Param("date") LocalDate date);
+
+    @Modifying
+    @Query("UPDATE Analytics a " +
+            "SET a.avgSessionTimeSec = (a.avgSessionTimeSec * a.clickCount + :sessionTime) / (a.clickCount + 1), " +
+            "    a.clickCount = a.clickCount + 1 " +
+            "WHERE a.event.id = :eventId AND a.date = :date")
+    int updateAverageDuration(@Param("eventId") Long eventId,
+                              @Param("date") LocalDate date,
+                              @Param("sessionTime") long sessionTime);
 }

--- a/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
+++ b/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
@@ -23,7 +23,7 @@ public interface AnalyticsRespository extends JpaRepository<Analytics,Long> {
 
     @Modifying
     @Query("UPDATE Analytics a " +
-            "SET a.avgSessionTimeSec = (a.avgSessionTimeSec * a.clickCount + :sessionTime) / a.clickCount " +
+            "SET a.avgSessionTimeSec = (a.avgSessionTimeSec * (a.clickCount - 1) + :sessionTime) / a.clickCount " +
             "WHERE a.event.id = :eventId AND a.date = :date")
     int updateAverageDuration(@Param("eventId") Long eventId,
                               @Param("date") LocalDate date,

--- a/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
+++ b/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
@@ -22,8 +22,7 @@ public interface AnalyticsRespository extends JpaRepository<Analytics,Long> {
 
     @Modifying
     @Query("UPDATE Analytics a " +
-            "SET a.avgSessionTimeSec = (a.avgSessionTimeSec * a.clickCount + :sessionTime) / (a.clickCount + 1), " +
-            "    a.clickCount = a.clickCount + 1 " +
+            "SET a.avgSessionTimeSec = (a.avgSessionTimeSec * a.clickCount + :sessionTime) / a.clickCount " +
             "WHERE a.event.id = :eventId AND a.date = :date")
     int updateAverageDuration(@Param("eventId") Long eventId,
                               @Param("date") LocalDate date,

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -47,7 +47,7 @@ public class AnalyticsCommandService {
         if(data==null){
             throw new GeneralException(AnalyticsErrorCode.REDIS_NOT_FOUND);
         }
-        if(data.getEventId()!=eventId){
+        if (!data.getEventId().equals(eventId)) {
             throw new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID);
         }
         LocalDateTime enterTime = data.getEnterTime();

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -36,11 +36,14 @@ public class AnalyticsCommandService {
         }
     }
 
-    public void sessionExit(String sessionId){
+    public void sessionExit(String sessionId,Long eventId){
 
         RedisSessionTracker.SessionData data=redisSessionTracker.exit(sessionId);
         if(data==null){
             throw new GeneralException(AnalyticsErrorCode.REDIS_NOT_FOUND);
+        }
+        if(data.getEventId()!=eventId){
+            throw new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID);
         }
         LocalDateTime enterTime = data.getEnterTime();
         LocalDateTime exitTime= LocalDateTime.now();

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -1,8 +1,6 @@
 package backend.onmoim.domain.analytics.service;
 
 import backend.onmoim.domain.analytics.code.AnalyticsErrorCode;
-import backend.onmoim.domain.analytics.converter.AnalyticsConverter;
-import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
 import backend.onmoim.domain.analytics.repository.AnalyticsRespository;
 import backend.onmoim.global.common.exception.GeneralException;
 import backend.onmoim.global.common.session.RedisSessionTracker;
@@ -38,10 +36,12 @@ public class AnalyticsCommandService {
         }
     }
 
-    public AnalyticsResDto.SessionEndResDto sessionExit(Long eventId, String sessionId){
+    public void sessionExit(String sessionId){
 
         RedisSessionTracker.SessionData data=redisSessionTracker.exit(sessionId);
-
+        if(data==null){
+            throw new GeneralException(AnalyticsErrorCode.REDIS_NOT_FOUND);
+        }
         LocalDateTime enterTime = data.getEnterTime();
         LocalDateTime exitTime= LocalDateTime.now();
 
@@ -49,7 +49,5 @@ public class AnalyticsCommandService {
         long seconds = duration.getSeconds();
 
         analyticsRepository.updateAverageDuration(data.getEventId(),LocalDate.now(),seconds);
-
-        return AnalyticsConverter.toSessionEndDTO(sessionId,seconds);
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -1,17 +1,20 @@
 package backend.onmoim.domain.analytics.service;
 
 import backend.onmoim.domain.analytics.code.AnalyticsErrorCode;
-import backend.onmoim.domain.analytics.entity.Analytics;
+import backend.onmoim.domain.analytics.converter.AnalyticsConverter;
+import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
 import backend.onmoim.domain.analytics.repository.AnalyticsRespository;
 import backend.onmoim.global.common.exception.GeneralException;
 import backend.onmoim.global.common.session.RedisSessionTracker;
-import jakarta.persistence.OptimisticLockException;
+
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Transactional
 @Service
@@ -23,16 +26,30 @@ public class AnalyticsCommandService {
 
     public String sessionEnter(Long userId,Long eventId){
         String sessionId=redisSessionTracker.enter(userId,eventId);
-
         return sessionId;
     }
 
 
-    public void enterCount(Long eventId){
+    public void exitCount(Long eventId){
         LocalDate today = LocalDate.now();
         int updated = analyticsRepository.incrementClickCount(eventId, today);
         if (updated == 0) {
             throw new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID);
         }
+    }
+
+    public AnalyticsResDto.SessionEndResDto sessionExit(Long eventId, String sessionId){
+
+        RedisSessionTracker.SessionData data=redisSessionTracker.exit(sessionId);
+
+        LocalDateTime enterTime = data.getEnterTime();
+        LocalDateTime exitTime= LocalDateTime.now();
+
+        Duration duration = Duration.between(enterTime,exitTime);
+        long seconds = duration.getSeconds();
+
+        analyticsRepository.updateAverageDuration(data.getEventId(),LocalDate.now(),seconds);
+
+        return AnalyticsConverter.toSessionEndDTO(sessionId,seconds);
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -16,7 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
+
+import static backend.onmoim.domain.analytics.code.AnalyticsErrorCode.BAD_EVENT_ID;
 
 @Transactional
 @Service
@@ -34,10 +37,10 @@ public class AnalyticsCommandService {
 
 
     public void exitCount(Long eventId){
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         int updated = analyticsRepository.incrementClickCount(eventId, today);
         if (updated == 0) {
-            throw new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID);
+            throw new GeneralException(BAD_EVENT_ID);
         }
     }
 
@@ -48,10 +51,10 @@ public class AnalyticsCommandService {
             throw new GeneralException(AnalyticsErrorCode.REDIS_NOT_FOUND);
         }
         if (!data.getEventId().equals(eventId)) {
-            throw new GeneralException(AnalyticsErrorCode.BAD_EVENT_ID);
+            throw new GeneralException(BAD_EVENT_ID);
         }
         LocalDateTime enterTime = data.getEnterTime();
-        LocalDateTime exitTime= LocalDateTime.now();
+        LocalDateTime exitTime= LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
         Duration duration = Duration.between(enterTime,exitTime);
         long seconds = duration.getSeconds();
@@ -60,7 +63,7 @@ public class AnalyticsCommandService {
     }
 
     public void createDailyAnalyticsForAllEvents() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         List<Event> events = eventRepository.findAll();
 
         for(Event event : events){
@@ -76,5 +79,22 @@ public class AnalyticsCommandService {
                                     build();
             analyticsRepository.save(analytics);
         }
+    }
+
+    public void createTodayAnalyticsTable(Event event){
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        if(event==null){
+            throw new GeneralException(BAD_EVENT_ID);
+        }
+
+        Analytics analytics = Analytics.builder().
+                event(event).
+                date(today).
+                clickCount(0).
+                avgSessionTimeSec(0).
+                build();
+        analyticsRepository.save(analytics);
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -41,7 +41,22 @@ public class AnalyticsCommandService {
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         int updated = analyticsRepository.incrementClickCount(eventId, today);
         if (updated == 0) {
-            throw new GeneralException(BAD_EVENT_ID);
+
+            Event event = eventRepository.findById(eventId)
+                    .orElseThrow(() -> new GeneralException(BAD_EVENT_ID));
+
+            if (!analyticsRepository.existsByEventAndDate(event, today)) {
+                analyticsRepository.save(
+                        Analytics.builder()
+                                .event(event)
+                                .date(today)
+                                .clickCount(1)
+                                .avgSessionTimeSec(0)
+                                .build()
+                );
+            } else {
+                analyticsRepository.incrementClickCount(eventId, today);
+            }
         }
     }
 

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -75,7 +75,7 @@ public class AnalyticsCommandService {
         Duration duration = Duration.between(enterTime,exitTime);
         long seconds = duration.getSeconds();
 
-        analyticsRepository.updateAverageDuration(data.getEventId(),LocalDate.now(),seconds);
+        analyticsRepository.updateAverageDuration(data.getEventId(),LocalDate.now(ZoneId.of("Asia/Seoul")),seconds);
     }
 
     public void createDailyAnalyticsForAllEvents() {

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -10,6 +10,7 @@ import backend.onmoim.global.common.session.RedisSessionTracker;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,17 +68,18 @@ public class AnalyticsCommandService {
         List<Event> events = eventRepository.findAll();
 
         for(Event event : events){
-            if(analyticsRepository.existsByEventAndDate(event,today)){
-                continue;
-            }
-
             Analytics analytics = Analytics.builder().
                                     event(event).
                                     date(today).
                                     clickCount(0).
                                     avgSessionTimeSec(0).
                                     build();
-            analyticsRepository.save(analytics);
+
+            try {
+                analyticsRepository.save(analytics);
+            } catch (DataIntegrityViolationException e) {
+                // 이미 존재시 아무것도 안함
+            }
         }
     }
 

--- a/src/main/java/backend/onmoim/domain/event/entity/Event.java
+++ b/src/main/java/backend/onmoim/domain/event/entity/Event.java
@@ -13,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Event {
-
+    @Column(name = "event_id")
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
+++ b/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -22,13 +23,14 @@ public class RedisSessionTracker {
    private final ObjectMapper objectMapper;
    private final RedisTemplate<String,String> redisTemplate;
 
-   @Data
-   @AllArgsConstructor
-   static class SessionData{
-       private Long userId;
-       private Long eventId;
-       private LocalDateTime enterTime;
-   }
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SessionData {
+        private Long userId;
+        private Long eventId;
+        private LocalDateTime enterTime;
+    }
 
    public String enter(Long userId,Long eventId){
        String sessionId = UUID.randomUUID().toString();
@@ -42,5 +44,22 @@ public class RedisSessionTracker {
        }
 
        return sessionId;
+   }
+
+   public SessionData exit(String sessionId){
+       String key =KEY_PREFIX + sessionId;
+       String json = redisTemplate.opsForValue().get(key);
+       if(json==null){
+           throw new GeneralException(AnalyticsErrorCode.REDIS_NOT_FOUND);
+       }
+
+       try{
+           SessionData data = objectMapper.readValue(json, SessionData.class);
+           // Redis에서 삭제
+           redisTemplate.delete(sessionId);
+           return data;
+       } catch (JsonProcessingException e) {
+           throw new GeneralException(AnalyticsErrorCode.REDIS_DESERIALIZE_FAIL);
+       }
    }
 }

--- a/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
+++ b/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
@@ -56,7 +56,7 @@ public class RedisSessionTracker {
        try{
            SessionData data = objectMapper.readValue(json, SessionData.class);
            // Redis에서 삭제
-           redisTemplate.delete(sessionId);
+           redisTemplate.delete(key);
            return data;
        } catch (JsonProcessingException e) {
            throw new GeneralException(AnalyticsErrorCode.REDIS_DESERIALIZE_FAIL);

--- a/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
+++ b/src/main/java/backend/onmoim/global/common/session/RedisSessionTracker.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.UUID;
 
 
@@ -34,7 +35,7 @@ public class RedisSessionTracker {
 
    public String enter(Long userId,Long eventId){
        String sessionId = UUID.randomUUID().toString();
-       SessionData data = new SessionData(userId,eventId,LocalDateTime.now());
+       SessionData data = new SessionData(userId,eventId,LocalDateTime.now(ZoneId.of("Asia/Seoul")));
 
        try {
            String json = objectMapper.writeValueAsString(data);

--- a/src/main/java/backend/onmoim/global/config/SchedularConfig.java
+++ b/src/main/java/backend/onmoim/global/config/SchedularConfig.java
@@ -1,0 +1,9 @@
+package backend.onmoim.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedularConfig {
+}

--- a/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
+++ b/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
@@ -1,0 +1,18 @@
+package backend.onmoim.global.schedular;
+
+import backend.onmoim.domain.analytics.repository.AnalyticsRespository;
+import backend.onmoim.domain.analytics.service.AnalyticsCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnalyticsScheduler {
+    private final AnalyticsCommandService analyticsCommandService;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void generateDailyAnalytics(){
+        analyticsCommandService.createDailyAnalyticsForAllEvents();
+    }
+}

--- a/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
+++ b/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class AnalyticsScheduler {
     private final AnalyticsCommandService analyticsCommandService;
 
-    @Scheduled(cron = "0 0 0 * * ?")
+    @Scheduled(cron = "0 0 0 * * ?",zone="Asia/Seoul")
     public void generateDailyAnalytics(){
         analyticsCommandService.createDailyAnalyticsForAllEvents();
     }

--- a/src/main/java/backend/onmoim/global/validation/annotation/ExistEvent.java
+++ b/src/main/java/backend/onmoim/global/validation/annotation/ExistEvent.java
@@ -1,0 +1,17 @@
+package backend.onmoim.global.validation.annotation;
+
+import backend.onmoim.global.validation.validator.EventIdExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = EventIdExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistEvent {
+    String message() default "Event ID가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/backend/onmoim/global/validation/validator/EventIdExistValidator.java
+++ b/src/main/java/backend/onmoim/global/validation/validator/EventIdExistValidator.java
@@ -17,6 +17,10 @@ public class EventIdExistValidator implements ConstraintValidator<ExistEvent,Lon
 
     @Override
     public boolean isValid(Long values, ConstraintValidatorContext context) {
+        if(values==null){
+            return true;
+        }
+
 
         boolean isValid = eventRepository.existsById(values);
 

--- a/src/main/java/backend/onmoim/global/validation/validator/EventIdExistValidator.java
+++ b/src/main/java/backend/onmoim/global/validation/validator/EventIdExistValidator.java
@@ -1,0 +1,30 @@
+package backend.onmoim.global.validation.validator;
+
+import backend.onmoim.domain.analytics.code.AnalyticsErrorCode;
+import backend.onmoim.domain.analytics.repository.AnalyticsRespository;
+import backend.onmoim.domain.event.repository.EventRepository;
+import backend.onmoim.global.validation.annotation.ExistEvent;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventIdExistValidator implements ConstraintValidator<ExistEvent,Long> {
+
+    private final EventRepository eventRepository;
+
+    @Override
+    public boolean isValid(Long values, ConstraintValidatorContext context) {
+
+        boolean isValid = eventRepository.existsById(values);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(AnalyticsErrorCode.BAD_EVENT_ID.getMessage()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
<img width="759" height="184" alt="image" src="https://github.com/user-attachments/assets/154014e0-db2b-454f-a635-9f2b093925ce" />
새로운 날짜별 통계 테이블을 생성합니다

## 🔗 관련 이슈
- closes #1

---

## 💡 추가 사항
멱등성 확보를 위해서  Event.java 컬럼 매핑, Analytics.java unique 제약 조건 추가 
대표 컨트롤러만 api Swagger 추가 하였고 스케줄러는 추가 하지않음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 세션 종료 API 추가: 세션 ID 반환, 종료 시간 기록 및 세션 지속시간을 일일 평균에 반영.
  * 매일 자정 자동 생성: 모든 이벤트에 대한 일일 분석 데이터 자동 생성 기능 추가.
  * 세션 시작은 입장 시간만 기록하도록 명확화.
  
* **Bug Fixes**
  * 세션 추적 안정성 향상: Redis에 데이터가 없거나 역직렬화 실패 시 명확한 오류 응답 추가.
  * 이벤트 ID 검증 강화: 존재하지 않는 이벤트에 대한 사전 검사로 잘못된 요청 차단.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->