### PR TITLE
[Feat] 기존 조회 API response에 이미지 presigned URL 추가

### DIFF
--- a/src/main/java/backend/onmoim/domain/user/controller/UserController.java
+++ b/src/main/java/backend/onmoim/domain/user/controller/UserController.java
@@ -47,7 +47,7 @@ public class UserController implements UserControllerDocs {
     @GetMapping("")
     public ApiResponse<UserProfileDTO> getMyProfile(
             @AuthenticationPrincipal User user) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, userQueryService.getMyProfile(user));  // User 전달
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, userQueryService.getMyProfile(user));
     }
       
     @Override

--- a/src/main/java/backend/onmoim/domain/user/dto/res/UserProfileDTO.java
+++ b/src/main/java/backend/onmoim/domain/user/dto/res/UserProfileDTO.java
@@ -13,4 +13,5 @@ public class UserProfileDTO {
     private String instagramId;
     private String twitterId;
     private String linkedinId;
+    private String profileImageUrl;
 }

--- a/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
@@ -111,7 +111,12 @@ public class UserQueryServiceImpl implements UserQueryService{
         }
 
         UserProfileDTO dto = UserConverter.toProfileDTO(user);
-        String imageUrl = minioUtil.getProfileImageUrl(user.getId());
+        String imageUrl = null;
+        try {
+                imageUrl = minioUtil.getProfileImageUrl(user.getId());
+            } catch (Exception e) {
+                log.warn("프로필 이미지 URL 생성 실패: {}", e.getMessage(), e);
+            }
         dto.setProfileImageUrl(imageUrl);
 
         return dto;

--- a/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/user/service/UserQueryServiceImpl.java
@@ -109,7 +109,12 @@ public class UserQueryServiceImpl implements UserQueryService{
         if (user.getStatus() != Status.ACTIVE) {
             throw new GeneralException(GeneralErrorCode.USER_INACTIVE);
         }
-        return UserConverter.toProfileDTO(user);
+
+        UserProfileDTO dto = UserConverter.toProfileDTO(user);
+        String imageUrl = minioUtil.getProfileImageUrl(user.getId());
+        dto.setProfileImageUrl(imageUrl);
+
+        return dto;
     }
 
     @Transactional


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
<img width="959" height="629" alt="스크린샷 2026-02-04 오전 12 44 23" src="https://github.com/user-attachments/assets/67ee8693-8bf3-47b9-97ff-70a949ad27f8" />

### 프로필 조회 API에 이미지 URL 추가

- 기존 회원 프로필 조회 API에 프로필 이미지 URL 응답 추가
- MinIO presigned URL을 통한 안전한 이미지 접근 제공

**주요 변경사항**
1. `GET /api/v1/users` API 응답에 `profileImageUrl` 필드 추가
2. UserProfileDTO에 프로필 이미지 URL 필드 추가
3. UserQueryServiceImpl에서 MinIO presigned URL 생성 로직 구현
4. 이미지가 없는 경우 null 반환 처리

**기술적 구현**
- MinIO presigned URL 생성으로 보안성 확보
- 이미지 존재 여부 확인 후 URL 생성
- 기존 API 구조 유지하면서 이미지 정보 확장


---

## 🔗 관련 이슈
- closes #32

---

## 💡 추가 사항
- 프로필 이미지가 없는 경우 profileImageUrl은 null 반환



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 내 프로필 조회 응답에 프로필 이미지 URL(profileImageUrl)이 추가되었습니다. 클라이언트는 해당 URL로 사용자 프로필 이미지를 표시할 수 있습니다.
  * 응답 구조의 기존 필드는 유지되어 하위 호환성이 보장됩니다. 별도 설정 변경 없이 즉시 활용 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->