### PR TITLE
[feat]  일주일치 통계 자료 가져오기

### DIFF
--- a/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
+++ b/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
@@ -12,8 +12,8 @@ public enum AnalyticsErrorCode implements BaseErrorCode {
     REDIS_SAVE_FAIL(HttpStatus.BAD_REQUEST,"ANALYTICS_401", "Redis에 세션 저장 실패"),
     BAD_EVENT_ID(HttpStatus.NOT_FOUND,"ANALYTICS_402", "해당 eventID 데이터를 찾을 수 없습니다."),
     REDIS_NOT_FOUND(HttpStatus.NOT_FOUND,"ANALYTICS_403","SESSION에 저장되지 않는 키입니다"),
-    REDIS_DESERIALIZE_FAIL(HttpStatus.BAD_REQUEST,"ANALYTICS_405","역직렬화에 실패했습니다");
-
+    REDIS_DESERIALIZE_FAIL(HttpStatus.BAD_REQUEST,"ANALYTICS_405","역직렬화에 실패했습니다"),
+    NOT_HOST(HttpStatus.UNAUTHORIZED,"ANALYRICS_406","행사의 호스트가 아닙니다");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
+++ b/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsErrorCode.java
@@ -13,7 +13,7 @@ public enum AnalyticsErrorCode implements BaseErrorCode {
     BAD_EVENT_ID(HttpStatus.NOT_FOUND,"ANALYTICS_402", "해당 eventID 데이터를 찾을 수 없습니다."),
     REDIS_NOT_FOUND(HttpStatus.NOT_FOUND,"ANALYTICS_403","SESSION에 저장되지 않는 키입니다"),
     REDIS_DESERIALIZE_FAIL(HttpStatus.BAD_REQUEST,"ANALYTICS_405","역직렬화에 실패했습니다"),
-    NOT_HOST(HttpStatus.UNAUTHORIZED,"ANALYRICS_406","행사의 호스트가 아닙니다");
+    NOT_HOST(HttpStatus.UNAUTHORIZED,"ANALYTICS_406","행사의 호스트가 아닙니다");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsSuccessCode.java
+++ b/src/main/java/backend/onmoim/domain/analytics/code/AnalyticsSuccessCode.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum AnalyticsSuccessCode implements BaseSuccessCode {
     REQUEST_OK(HttpStatus.OK,
             "SESSION_200",
-            "세션이 성공적으로 처리되었습니다.");
-
+            "세션이 성공적으로 처리되었습니다."),
+    GET_ANALYTICS(HttpStatus.OK,"ANALYTICS_201","통계 정보를 성공적으로 불러왔습니다");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsController.java
@@ -10,10 +10,7 @@ import backend.onmoim.global.validation.annotation.ExistEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Validated
 @RestController
@@ -47,6 +44,15 @@ public class AnalyticsController implements AnalyticsControllerDocs{
                 AnalyticsSuccessCode.REQUEST_OK,
                 AnalyticsConverter.toSessionEndDTO(sessionId)
         );
+    }
+
+    @Override
+    @GetMapping("/total")
+    public ApiResponse<AnalyticsResDto.GetAnalyticsListDto> analyticsGet(@AuthenticationPrincipal User user,@ExistEvent @RequestParam Long eventId){
+        Long userId=user.getId();
+
+        return ApiResponse.onSuccess(AnalyticsSuccessCode.REQUEST_OK,
+                analyticsCommendService.analyticsGet(userId,eventId));
     }
 }
 

--- a/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
+++ b/src/main/java/backend/onmoim/domain/analytics/controller/AnalyticsControllerDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @Tag(name = "Event 통계 API", description = "통계 관련 API")
@@ -18,4 +19,8 @@ public interface AnalyticsControllerDocs {
 
     @Operation(summary = "퇴장 시간 기록 및 머문 시간 계산", description = "머문 시간을 측정하고 click 수를 카운트 합니다 평균을 계산합니다")
     public ApiResponse<AnalyticsResDto.SessionEndResDto> sessionEnd(@ExistEvent @PathVariable Long eventId,@PathVariable String sessionId);
+
+
+    @Operation(summary = "일주일치 통계 자료 획득", description = "일주일치 통계자료를 일별로 획득합니다.")
+    public ApiResponse<AnalyticsResDto.GetAnalyticsListDto> analyticsGet(@AuthenticationPrincipal User user,@ExistEvent @RequestParam Long eventId);
 }

--- a/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
+++ b/src/main/java/backend/onmoim/domain/analytics/converter/AnalyticsConverter.java
@@ -1,6 +1,7 @@
 package backend.onmoim.domain.analytics.converter;
 
 import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
+import backend.onmoim.domain.analytics.entity.Analytics;
 
 public class AnalyticsConverter {
 
@@ -17,6 +18,25 @@ public class AnalyticsConverter {
     ){
         return AnalyticsResDto.SessionEndResDto.builder()
                 .sessionId(sessionId)
+                .build();
+    }
+
+    public static AnalyticsResDto.DailyAnalyticsDto toDailyDto(Analytics a, int totalParticipants) {
+        long totalSeconds = a.getAvgSessionTimeSec();
+        int minutes = (int) totalSeconds / 60;
+        int seconds = (int) totalSeconds % 60;
+
+        return AnalyticsResDto.DailyAnalyticsDto.builder()
+                .date(a.getDate())
+                .clickCount(a.getClickCount())
+                .participantCount(totalParticipants)
+                .avgSession(AnalyticsResDto.AvgSessionDto.builder()
+                        .minutes(minutes)
+                        .seconds(seconds)
+                        .build())
+                .participationRate(totalParticipants > 0
+                        ? ((double) a.getClickCount() / totalParticipants) * 100
+                        : 0.0)
                 .build();
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
+++ b/src/main/java/backend/onmoim/domain/analytics/dto/res/AnalyticsResDto.java
@@ -1,6 +1,10 @@
 package backend.onmoim.domain.analytics.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public class AnalyticsResDto {
     @Builder
@@ -8,4 +12,25 @@ public class AnalyticsResDto {
 
     @Builder
     public record SessionEndResDto(String sessionId){}
+
+    @JsonAutoDetect
+    @Builder
+    public record AvgSessionDto(int minutes, int seconds) {}
+
+    @JsonAutoDetect
+    @Builder
+    public record DailyAnalyticsDto (
+            LocalDate date,
+            int clickCount,
+            int participantCount,
+            AvgSessionDto avgSession,
+            double participationRate
+    ) {}
+
+    @JsonAutoDetect
+    @Builder
+    public record GetAnalyticsListDto (
+            Long eventId,
+            List<DailyAnalyticsDto> stats
+    ){}
 }

--- a/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
+++ b/src/main/java/backend/onmoim/domain/analytics/entity/Analytics.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 @Entity
 @Builder
 @Getter
+@Setter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access=AccessLevel.PROTECTED)
 @Table(
@@ -33,6 +34,9 @@ public class Analytics {
 
     @Column(nullable = false)
     private long avgSessionTimeSec;
+
+    @Column(nullable = false)
+    private int participantNum;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id",nullable = false)

--- a/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
+++ b/src/main/java/backend/onmoim/domain/analytics/repository/AnalyticsRespository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -30,4 +31,11 @@ public interface AnalyticsRespository extends JpaRepository<Analytics,Long> {
                               @Param("sessionTime") long sessionTime);
 
     boolean existsByEventAndDate(Event event, LocalDate date);
+
+    @Query("SELECT a FROM Analytics a WHERE a.event.id = :eventId AND :startDate <= a.date AND a.date<= :endDate ORDER BY a.date ASC")
+    List<Analytics> countWeeklyAnalytics(@Param("eventId") Long eventId,
+                                         @Param("startDate") LocalDate startDate,
+                                         @Param("endDate") LocalDate endDate);
+
+    List<Analytics> findAllByDate(LocalDate date);
 }

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -150,10 +150,14 @@ public class AnalyticsCommandService {
         LocalDate startDate = endDate.minusDays(6);
 
         List<Analytics> analyticsList = analyticsRepository.countWeeklyAnalytics(eventId, startDate, endDate);
-        int totalParticipants = participationRepository.countAttendedByEventId(eventId);
+        int realTimeParticipants = participationRepository.countAttendedByEventId(eventId);
 
         List<AnalyticsResDto.DailyAnalyticsDto> stats = analyticsList.stream()
-                .map(a -> AnalyticsConverter.toDailyDto(a, totalParticipants))
+                .map(a -> {
+                    // 오늘 데이터면 실시간 값을 쓰고, 과거 데이터면 DB에 저장된 값을 씀
+                    int pNum = a.getDate().equals(endDate) ? realTimeParticipants : a.getParticipantNum();
+                    return AnalyticsConverter.toDailyDto(a, pNum);
+                })
                 .collect(Collectors.toList());
 
         return new AnalyticsResDto.GetAnalyticsListDto(eventId, stats);

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -1,10 +1,13 @@
 package backend.onmoim.domain.analytics.service;
 
 import backend.onmoim.domain.analytics.code.AnalyticsErrorCode;
+import backend.onmoim.domain.analytics.converter.AnalyticsConverter;
+import backend.onmoim.domain.analytics.dto.res.AnalyticsResDto;
 import backend.onmoim.domain.analytics.entity.Analytics;
 import backend.onmoim.domain.analytics.repository.AnalyticsRespository;
 import backend.onmoim.domain.event.entity.Event;
 import backend.onmoim.domain.event.repository.EventRepository;
+import backend.onmoim.domain.event.repository.ParticipationRepository;
 import backend.onmoim.global.common.exception.GeneralException;
 import backend.onmoim.global.common.session.RedisSessionTracker;
 
@@ -19,8 +22,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static backend.onmoim.domain.analytics.code.AnalyticsErrorCode.BAD_EVENT_ID;
+import static backend.onmoim.domain.analytics.code.AnalyticsErrorCode.NOT_HOST;
 
 @Transactional
 @Service
@@ -30,6 +35,7 @@ public class AnalyticsCommandService {
     private final RedisSessionTracker redisSessionTracker;
     private final AnalyticsRespository analyticsRepository;
     private final EventRepository eventRepository;
+    private final ParticipationRepository participationRepository;
 
     public String sessionEnter(Long userId,Long eventId){
         String sessionId=redisSessionTracker.enter(userId,eventId);
@@ -113,5 +119,43 @@ public class AnalyticsCommandService {
                 avgSessionTimeSec(0).
                 build();
         analyticsRepository.save(analytics);
+    }
+
+    public void countTodayFinalParticipantNum(){
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        List<Analytics> analyticsList = analyticsRepository.findAllByDate(today);
+
+        for (Analytics analytics : analyticsList) {
+            Long eventId = analytics.getEvent().getId();
+
+            int participantCount = participationRepository.countAttendedByEventId(eventId);
+
+            analytics.setParticipantNum(participantCount);
+            analyticsRepository.save(analytics);
+        }
+    }
+
+
+    public AnalyticsResDto.GetAnalyticsListDto analyticsGet(Long userId, Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new GeneralException(BAD_EVENT_ID));
+
+        if (!event.getHost().getId().equals(userId)) {
+            throw new GeneralException(NOT_HOST);
+        }
+
+        LocalDate startDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate endDate = startDate.minusDays(6);
+
+        List<Analytics> analyticsList = analyticsRepository.countWeeklyAnalytics(eventId, startDate, endDate);
+        int totalParticipants = participationRepository.countAttendedByEventId(eventId);
+
+        List<AnalyticsResDto.DailyAnalyticsDto> stats = analyticsList.stream()
+                .map(a -> AnalyticsConverter.toDailyDto(a, totalParticipants))
+                .collect(Collectors.toList());
+
+        return new AnalyticsResDto.GetAnalyticsListDto(eventId, stats);
     }
 }

--- a/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
+++ b/src/main/java/backend/onmoim/domain/analytics/service/AnalyticsCommandService.java
@@ -146,8 +146,8 @@ public class AnalyticsCommandService {
             throw new GeneralException(NOT_HOST);
         }
 
-        LocalDate startDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        LocalDate endDate = startDate.minusDays(6);
+        LocalDate endDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate startDate = endDate.minusDays(6);
 
         List<Analytics> analyticsList = analyticsRepository.countWeeklyAnalytics(eventId, startDate, endDate);
         int totalParticipants = participationRepository.countAttendedByEventId(eventId);

--- a/src/main/java/backend/onmoim/domain/event/entity/Event.java
+++ b/src/main/java/backend/onmoim/domain/event/entity/Event.java
@@ -1,6 +1,7 @@
 package backend.onmoim.domain.event.entity;
 
 import backend.onmoim.domain.analytics.entity.Analytics;
+import backend.onmoim.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -32,4 +33,8 @@ public class Event {
 
     @OneToMany(mappedBy = "event")
     private List<Analytics> analytics = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id")
+    private User host;
 }

--- a/src/main/java/backend/onmoim/domain/event/repository/ParticipationRepository.java
+++ b/src/main/java/backend/onmoim/domain/event/repository/ParticipationRepository.java
@@ -4,6 +4,9 @@ import backend.onmoim.domain.event.entity.Event;
 import backend.onmoim.domain.event.entity.Participation;
 import backend.onmoim.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
@@ -13,5 +16,8 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     // 특정 행사의 모든 참여자 목록 가져오기
     java.util.List<Participation> findAllByEvent(Event event);
+
+    @Query("SELECT COUNT(p) FROM Participation p WHERE p.event.id = :eventId AND p.status = 'ATTEND'")
+    int countAttendedByEventId(@Param("eventId") Long eventId);
 }
 //DB에서 "내가 이 행사에 투표한 적이 있나?"를 확인

--- a/src/main/java/backend/onmoim/domain/user/entity/User.java
+++ b/src/main/java/backend/onmoim/domain/user/entity/User.java
@@ -61,6 +61,7 @@ public class User extends BaseEntity {
     @JoinColumn(name = "profile_image_id")
     private ProfileImage profileImage;
 
+    @Builder.Default
     @OneToMany(mappedBy = "host")
     private List<Event> events = new ArrayList<>();
 

--- a/src/main/java/backend/onmoim/domain/user/entity/User.java
+++ b/src/main/java/backend/onmoim/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package backend.onmoim.domain.user.entity;
 
 
+import backend.onmoim.domain.event.entity.Event;
 import backend.onmoim.domain.user.enums.Status;
 import backend.onmoim.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -10,6 +11,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Entity
@@ -57,6 +60,10 @@ public class User extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, optional = true)
     @JoinColumn(name = "profile_image_id")
     private ProfileImage profileImage;
+
+    @OneToMany(mappedBy = "host")
+    private List<Event> events = new ArrayList<>();
+
 
     // 회원 정보 수정
     public void updateProfile(String nickname,

--- a/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
+++ b/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
@@ -15,4 +15,8 @@ public class AnalyticsScheduler {
     public void generateDailyAnalytics(){
         analyticsCommandService.createDailyAnalyticsForAllEvents();
     }
+
+
+    @Scheduled(cron = "55 59 23 * * ?",zone="Asia/Seoul")
+    public void storeParticipantNum() {analyticsCommandService.countTodayFinalParticipantNum();}
 }

--- a/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
+++ b/src/main/java/backend/onmoim/global/schedular/AnalyticsScheduler.java
@@ -17,6 +17,6 @@ public class AnalyticsScheduler {
     }
 
 
-    @Scheduled(cron = "55 59 23 * * ?",zone="Asia/Seoul")
+    @Scheduled(cron = "0 59 23 * * ?",zone="Asia/Seoul")
     public void storeParticipantNum() {analyticsCommandService.countTodayFinalParticipantNum();}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: onmoim
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver # MySQL JDBC 드라이버 클래스 이름
-    url: ${DB_URL} # jdbc:mysql://localhost:3306/{데이터베이스명}
+    url: jdbc:mysql://localhost:3306/onmoim # jdbc:mysql://localhost:3306/{데이터베이스명}
     username: ${DB_USER} # MySQL 유저 이름
     password: ${DB_PW} # MySQL 비밀번호
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: onmoim
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver # MySQL JDBC 드라이버 클래스 이름
-    url: jdbc:mysql://localhost:3306/onmoim # jdbc:mysql://localhost:3306/{데이터베이스명}
+    url: ${DB_URL} # jdbc:mysql://localhost:3306/{데이터베이스명}
     username: ${DB_USER} # MySQL 유저 이름
     password: ${DB_PW} # MySQL 비밀번호
   jpa:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
<img width="688" height="497" alt="스크린샷 2026-02-05 165414" src="https://github.com/user-attachments/assets/f0f6ab38-ba50-45a2-9c25-ece717b9fcb6" />

---

## 🔗 관련 이슈
- closes #1

---

## 💡 추가 사항
analytics 페이지 컬럼 추가
스케줄러를 통한 매일 참가자 수 확인 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 이벤트 호스트를 위한 주간 분석 조회 API 추가 — 일별 클릭 수, 참여자 수, 평균 세션 시간(분/초), 참여율 제공
  * 이벤트 호스트 권한 검증 추가(호스트가 아닌 경우 접근 차단)
  * 일일 참여자 수 최종 집계 자동화 추가 — 매일 23:59에 집계 실행
  * 분석 조회 성공/오류 코드 및 응답 형식(일별 통계 DTO) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->