### PR TITLE
fix: 행사 투표 여부 조회 로직 수정

### DIFF
--- a/src/main/java/backend/onmoim/domain/event/controller/EventController.java
+++ b/src/main/java/backend/onmoim/domain/event/controller/EventController.java
@@ -5,6 +5,7 @@ import backend.onmoim.domain.event.dto.res.EventDetailResponse;
 import backend.onmoim.domain.event.dto.res.EventListResponse;
 import backend.onmoim.domain.event.dto.res.EventResDTO;
 import backend.onmoim.domain.event.dto.res.EventUpdateDTO;
+import backend.onmoim.domain.event.dto.res.ParticipantDto;
 import backend.onmoim.domain.event.service.EventService;
 import backend.onmoim.domain.user.entity.User;
 import backend.onmoim.global.common.ApiResponse;
@@ -53,12 +54,19 @@ public class EventController {
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, response);
     }
 
-    @PostMapping("/events/{eventId}/vote")
+    @PostMapping("/events/{eventId}/participants/{userId}")
     public ApiResponse<String> castVote(@PathVariable Long eventId,
+                                        @PathVariable Long userId,
                                         @AuthenticationPrincipal User user,
                                         @RequestBody VoteRequest request) {
         eventService.castVote(eventId, user, request);
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, "투표가 완료되었습니다.");
+    }
+
+    @GetMapping("/events/{eventId}/participants")
+    public ApiResponse<List<ParticipantDto>> getParticipants(@PathVariable Long eventId) {
+        List<ParticipantDto> participants = eventService.getParticipants(eventId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, participants);
     }
 
     @DeleteMapping("/events/{eventId}")

--- a/src/main/java/backend/onmoim/domain/event/dto/res/ParticipantDto.java
+++ b/src/main/java/backend/onmoim/domain/event/dto/res/ParticipantDto.java
@@ -1,0 +1,22 @@
+package backend.onmoim.domain.event.dto.res;
+
+import backend.onmoim.domain.event.entity.EventMember;
+import backend.onmoim.domain.event.enums.VoteStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParticipantDto {
+    private Long userId;
+    private String nickname;
+    private VoteStatus status;
+
+    public static ParticipantDto from(EventMember member) {
+        return ParticipantDto.builder()
+                .userId(member.getUser().getId())
+                .nickname(member.getUser().getNickname())
+                .status(member.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/backend/onmoim/domain/event/service/EventService.java
+++ b/src/main/java/backend/onmoim/domain/event/service/EventService.java
@@ -6,6 +6,7 @@ import backend.onmoim.domain.event.dto.res.EventListResponse;
 import backend.onmoim.domain.event.dto.res.EventResDTO;
 import backend.onmoim.domain.event.dto.res.EventUpdateDTO;
 import backend.onmoim.domain.user.entity.User;
+import backend.onmoim.domain.event.dto.res.ParticipantDto;
 
 import java.util.List;
 
@@ -20,4 +21,5 @@ public interface EventService {
     void castVote(Long eventId, User user, VoteRequest request);
 
     List<EventResDTO> getUserParticipatingEvents(Long userId);
+    List<ParticipantDto> getParticipants(Long eventId);
 }

--- a/src/main/java/backend/onmoim/domain/event/service/EventServiceImpl.java
+++ b/src/main/java/backend/onmoim/domain/event/service/EventServiceImpl.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import backend.onmoim.domain.analytics.service.AnalyticsCommandService;
+import backend.onmoim.domain.event.dto.res.ParticipantDto;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -129,6 +130,16 @@ public class EventServiceImpl implements EventService {
         List<Event> events = eventMemberRepository.findEventByUserId(userId);
         return  events.stream()
                 .map(EventConverter::toResDTO)
+                .collect(Collectors.toList());
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public List<ParticipantDto> getParticipants(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.EVENT_NOT_FOUND));
+
+        return eventMemberRepository.findAllByEvent(event).stream()
+                .map(ParticipantDto::from)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
1. 행사 목록 전체 조회 (Get List) 기능 추가
   - 메인 페이지용 API (GET /api/v1/users/events) 구현
   - 프론트엔드 요청에 맞춰 중첩 객체(Schedule, Location) 구조의 DTO(EventListResponse) 적용

2. 투표하기 (Vote) 기능 구현
   - EventMemberRepository 의존성 추가 및 투표 로직(castVote) 구현

3. 행사 삭제 (Delete) 보안 로직 수정 (Fix)
   - Controller: 삭제 요청 시 User 정보 수신하도록 수정
   - Service: 요청한 유저가 행사의 호스트(Host)인지 검증하는 로직 복구 (타인 행사 삭제 방지)

4. Entity 및 DTO 동기화
   - Event 엔티티에 capacity(수용인원), playlistUrl 컬럼 추가
   - 상세 조회(EventDetailResponse) 및 목록 조회 DTO에 해당 필드 매핑

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
새로운 기능 추가(명단 조회), API 주소 수정(투표),

## 🔗 관련 이슈
- closes #1

---

## 💡 추가 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이벤트 참가자 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 각 참가자의 아이디, 닉네임, 투표 상태 정보를 확인할 수 있습니다.
  
* **Bug Fixes**
  * 투표 제출 API 엔드포인트 경로가 변경되어 사용자 식별이 더욱 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->